### PR TITLE
[do not merge] Example of adding swipes to the queue instead

### DIFF
--- a/jukebox.sh
+++ b/jukebox.sh
@@ -31,5 +31,15 @@ while read -ep "Swipe: " INPUT; do
 		continue
 	fi
 
-	mpc stop -q && mpc clear -q && mpc add "$URI" && mpc play
+	# Add swipe to queue
+	mpc add "$URI"
+
+	# How many things are in the queue?
+	COUNT=$( mpc playlist | wc -l )
+
+	# If there's only one thing in the queue, that means it was just added so start playing.
+	# Otherwise it will restart the currently playing track instead of continuing on with the playlist.
+	if [[ "$COUNT" -eq 1 ]]
+		mpc play
+	fi
 done


### PR DESCRIPTION
If you execute mpc play when a track is currently playing it will restart that track, so we have to be smart and only tell it to start playing if it wasn't already playing. The seemingly easier way to do this isn't by parsing out the status but rather by counting how many songs are in the queue.

Potential problem: if you have paused and forgotten that it's paused, it will add to the queue but will not start playing. This is where parsing out the status might be better after all.